### PR TITLE
Add EGLImage and texture support with GBM buffer setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,8 @@
     "tuple": "cpp",
     "type_traits": "cpp",
     "utility": "cpp",
-    "compare": "cpp"
+    "compare": "cpp",
+    "string": "c",
+    "string_view": "c"
   }
 }

--- a/src/gfx_blit.cpp
+++ b/src/gfx_blit.cpp
@@ -10,6 +10,7 @@ extern "C" int gfx_blit(gfx_blit_image_t *src, gfx_blit_image_t *dst)
     int ret_status = gfx_blitter_t.load_extensions();
     if(ret_status == gfx_blitter_t.GFX_LOAD_EXT_FAIL) {
         cout << "[INFO]: Failed to load extensions" << endl;
+        return -1;
     }
     else {
         cout << "[INFO]: Loaded the extensions" << endl;
@@ -18,6 +19,7 @@ extern "C" int gfx_blit(gfx_blit_image_t *src, gfx_blit_image_t *dst)
     ret_status = gfx_context_t.get_wayaland_disp(&egl_res.wayland_display);
     if(ret_status == gfx_context_t.WAYLAND_DSPY_FAIL) {
         cout << "[INFO]: Failed to get wayland get display" << endl;
+        return -1;
     }
     else {
         cout  << "[INFO]: Connected to wayland display" << endl;
@@ -26,6 +28,7 @@ extern "C" int gfx_blit(gfx_blit_image_t *src, gfx_blit_image_t *dst)
     ret_status = gfx_context_t.gfx_egl_context_create(&egl_res);
     if(ret_status != gfx_context_t.GFX_EGL_CONTEXT_SUCCESS) {
         cout << "[INFO]: Failed to setup egl context creation" << endl;
+        return -1;
     }
     else {
         cout  << "[INFO]: EGL context creation success" << endl;
@@ -36,6 +39,23 @@ extern "C" int gfx_blit(gfx_blit_image_t *src, gfx_blit_image_t *dst)
     if(gfx_pipe_res.program <= 0) {
         cout << "[INFO]: Failed to creete the program" << endl;
     }
+
+    EGLImageKHR src_image = gfx_blitter_t.create_egl_image(src->bo, egl_res.egl_display, "INPUT ");
+    if(src_image == EGL_NO_IMAGE_KHR || src_image == NULL) {
+        printf("[ERROR]: Failed to create the src egl_image\n");
+        return -1;
+    }
+    EGLImageKHR dst_image = gfx_blitter_t.create_egl_image(dst->bo, egl_res.egl_display, "OUTPUT");
+    if(src_image == EGL_NO_IMAGE_KHR || src_image == NULL) {
+        printf("[ERROR]: Failed to create the dst egl_image\n");
+        return -1;
+    }
+
+    gfx_pipe_res.textures[0] = gfx_blitter_t.create_texture(src_image);
+    printf("[INFO]: Src texture ID = %d\n", gfx_pipe_res.textures[0]);
+
+    gfx_pipe_res.textures[1] = gfx_blitter_t.create_texture(dst_image);
+    printf("[INFO]: dst texture ID = %d\n", gfx_pipe_res.textures[1]);
 
     cout << "Executed the gfx_blit public api" << endl;
     return 0;

--- a/src/gfx_blitter.cpp
+++ b/src/gfx_blitter.cpp
@@ -113,3 +113,55 @@ int gfx_blitter::create_program()
         return program_id;
     }
 }
+
+EGLImageKHR gfx_blitter::create_egl_image(struct gbm_bo *bo, EGLDisplay display, char *type)
+{
+    EGLint width = gbm_bo_get_width(bo);
+    EGLint height = gbm_bo_get_height(bo);
+    EGLint stride = gbm_bo_get_stride(bo);
+    EGLint fd = gbm_bo_get_fd(bo);
+    EGLint bpp = gbm_bo_get_bpp(bo);
+    EGLint offset = gbm_bo_get_offset(bo,0);
+    EGLint format = gbm_bo_get_format(bo);
+    if(fd <= 0) {
+        printf("[ERROR]: Bcz of fd is < 1(%d)\n", fd);
+        return NULL;
+    }
+    else {
+        printf("[DEBUG]: %s: Width = %d, Height = %d, Stride = %d, Format = 0x%x, Offset = %d, fd = %d, bpp = %d\n",
+                type ,width, height, stride, format, offset, fd, bpp);
+    }
+
+    EGLint attrs[] = {
+        EGL_WIDTH, width,
+        EGL_HEIGHT, height,
+        EGL_LINUX_DRM_FOURCC_EXT, format,
+        EGL_DMA_BUF_PLANE0_FD_EXT, fd,
+        EGL_DMA_BUF_PLANE0_OFFSET_EXT, offset,
+        EGL_DMA_BUF_PLANE0_PITCH_EXT, stride,
+        EGL_NONE
+    };
+
+    EGLImageKHR image = eglCreateImageKHR(display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, NULL, attrs);
+    if(image == EGL_NO_IMAGE_KHR) {
+        printf("[ERROR]: Failed to create the EGLimageKHR");
+        return EGL_NO_IMAGE_KHR;
+    }
+
+    return image;
+}
+
+int gfx_blitter::create_texture(EGLImageKHR image)
+{
+    GLuint texture = 0;
+    glGenTextures(1,&texture);
+    glBindTexture(GL_TEXTURE_2D, texture);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+    return texture;
+}

--- a/src/gfx_blitter.h
+++ b/src/gfx_blitter.h
@@ -17,6 +17,8 @@ public:
     int create_program();
     int compile_shader(GLuint shader_type, const char *shader_source);
     void decide_shaders(const char **vertex_shader, const char **fragment_shader);
+    EGLImageKHR create_egl_image(struct gbm_bo *bo, EGLDisplay display, char *buffer_type);
+    int create_texture(EGLImageKHR image);
     typedef struct egl_resource {
         struct wl_display *wayland_display;
         EGLDisplay egl_display;

--- a/tests/simple_test.c
+++ b/tests/simple_test.c
@@ -1,19 +1,86 @@
 #include "gfx_blit.h"
+#include <gbm.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
-int main () {
-  gfx_blit_image_t *src = malloc(sizeof(gfx_blit_image_t));
-  gfx_blit_image_t *dst = malloc(sizeof(gfx_blit_image_t));
-  src->width = 512;
-  src->height = 512;
-  src->format = GFX_FORMAT_RGB888;
-  src->rotation = GFX_ROTATION_0;
+#include <string.h>
+#include <errno.h>
 
-  dst->width = 512;
-  dst->height = 514;
-  dst->format = GFX_FORMAT_ARGB8888;
-  dst->rotation = GFX_ROTATION_90;
+static int drm_fd = -1;
+static struct gbm_device *gbm_dev = NULL;
 
-  printf("Executing the test\n");
-  gfx_blit(src,dst);
+static void* create_image(gfx_blit_image_t *img, uint32_t width, uint32_t height, gfx_format_t fmt) {
+    uint32_t gbm_fmt;
+    switch (fmt) {
+        case GFX_FORMAT_RGB888:   gbm_fmt = GBM_FORMAT_RGB888; break;
+        case GFX_FORMAT_ARGB8888: gbm_fmt = GBM_FORMAT_ARGB8888; break;
+        case GFX_FORMAT_XRGB8888: gbm_fmt = GBM_FORMAT_XRGB8888; break;
+        default: fprintf(stderr, "Unsupported format\n"); return NULL;
+    }
+
+    struct gbm_bo *bo = gbm_bo_create(gbm_dev, width, height, gbm_fmt, GBM_BO_USE_LINEAR | GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT);
+    if (!bo) {
+        perror("gbm_bo_create failed");
+        return NULL;
+    }
+
+    uint32_t stride;
+    void *map_data = NULL;
+    void *ptr = gbm_bo_map(bo, 0, 0, width, height, GBM_BO_TRANSFER_READ_WRITE, &stride, &map_data);
+    if (!ptr) {
+        perror("gbm_bo_map failed");
+        gbm_bo_destroy(bo);
+        return NULL;
+    }
+
+    img->width = width;
+    img->height = height;
+    img->format = fmt;
+    img->bo = bo;
+    img->stride[0] = stride;
+    return ptr;
+}
+
+int main() {
+    drm_fd = open("/dev/dri/card1", O_RDWR | O_CLOEXEC);
+    if (drm_fd < 0) {
+        perror("Failed to open render node");
+        return 1;
+    }
+
+    gbm_dev = gbm_create_device(drm_fd);
+    if (!gbm_dev) {
+        perror("Failed to create GBM device");
+        close(drm_fd);
+        return 1;
+    }
+
+    gfx_blit_image_t *src = malloc(sizeof(gfx_blit_image_t));
+    gfx_blit_image_t *dst = malloc(sizeof(gfx_blit_image_t));
+
+    void *src_ptr = create_image(src, 512, 512, GFX_FORMAT_XRGB8888);
+    void *dst_ptr = create_image(dst, 512, 512, GFX_FORMAT_ARGB8888);
+
+    if (!src_ptr || !dst_ptr) {
+        fprintf(stderr, "Failed to allocate GBM images\n");
+        return 1;
+    }
+
+
+    src->rotation = GFX_ROTATION_0;
+    dst->rotation = GFX_ROTATION_90;
+
+    printf("Executing the test\n");
+    int status = gfx_blit(src, dst);
+    if (status != 0) {
+        fprintf(stderr, "gfx_blit failed with status %d\n", status);
+    }
+
+    free(src);
+    free(dst);
+
+    gbm_device_destroy(gbm_dev);
+    close(drm_fd);
+    return 0;
 }


### PR DESCRIPTION
- Create EGLImage from GBM buffers
- Bind EGLImage to GL texture
- Update gfx_blit and simple_test with GBM image handling