### PR TITLE
gfx_blit: add render() function and clean up pipeline

### DIFF
--- a/src/gfx_blit.cpp
+++ b/src/gfx_blit.cpp
@@ -49,14 +49,6 @@ extern "C" int gfx_blit(gfx_blit_image_t *src, gfx_blit_image_t *dst)
         printf("[DEBUG]: VBO = %d\n", gfx_pipe_res.vbo);
     }
 
-    ret_status = gfx_blitter_t.setup_gl_ver_Attr(&gfx_pipe_res.posAttrib, &gfx_pipe_res.texAttrib, gfx_pipe_res.program);
-    if(ret_status == gfx_blitter_t.GFX_GET_ATTRI_SUCCESS) {
-        printf("[INFO]: posAttrib Loc = %d, texAttrib Loc = %d\n", gfx_pipe_res.posAttrib, gfx_pipe_res.texAttrib);
-    }
-    else {
-        return -1;
-    }
-
     EGLImageKHR src_image = gfx_blitter_t.create_egl_image(src->bo, egl_res.egl_display, "INPUT ");
     if(src_image == EGL_NO_IMAGE_KHR || src_image == NULL) {
         printf("[ERROR]: Failed to create the src egl_image\n");
@@ -68,10 +60,10 @@ extern "C" int gfx_blit(gfx_blit_image_t *src, gfx_blit_image_t *dst)
         return -1;
     }
 
-    gfx_pipe_res.textures[0] = gfx_blitter_t.create_texture(src_image);
+    gfx_pipe_res.textures[0] = gfx_blitter_t.create_texture(src_image, egl_res.egl_display);
     printf("[INFO]: Src texture ID = %d\n", gfx_pipe_res.textures[0]);
 
-    gfx_pipe_res.textures[1] = gfx_blitter_t.create_texture(dst_image);
+    gfx_pipe_res.textures[1] = gfx_blitter_t.create_texture(dst_image, egl_res.egl_display);
     printf("[INFO]: dst texture ID = %d\n", gfx_pipe_res.textures[1]);
 
     gfx_pipe_res.fbo = gfx_blitter_t.create_fbo(gfx_pipe_res.textures[1], dst->width, dst->height);
@@ -79,6 +71,15 @@ extern "C" int gfx_blit(gfx_blit_image_t *src, gfx_blit_image_t *dst)
         printf("[INFO]: FBO ID = %d\n", gfx_pipe_res.fbo);
     }
     else {
+        return -1;
+    }
+
+    ret_status = gfx_blitter_t.render(gfx_pipe_res, dst->width, dst->height);
+    if(ret_status == gfx_blitter_t.GFX_RENDER_SUCCESS){
+        printf("[INFO]: Rendering got success\n");
+    }
+    else {
+        printf("[ERROR]: Rendering got failed\n");
         return -1;
     }
 

--- a/src/gfx_blitter.cpp
+++ b/src/gfx_blitter.cpp
@@ -151,7 +151,7 @@ EGLImageKHR gfx_blitter::create_egl_image(struct gbm_bo *bo, EGLDisplay display,
     return image;
 }
 
-int gfx_blitter::create_texture(EGLImageKHR image)
+int gfx_blitter::create_texture(EGLImageKHR image, EGLDisplay display)
 {
     GLuint texture = 0;
     glGenTextures(1,&texture);
@@ -163,6 +163,7 @@ int gfx_blitter::create_texture(EGLImageKHR image)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+    //eglDestroyImageKHR(display, image);
     return texture;
 }
 
@@ -212,4 +213,38 @@ int gfx_blitter::create_fbo(GLuint texture_id, uint32_t width, uint32_t height)
     }
 
     return fbo;
+}
+
+int gfx_blitter::render(gfx_pipeline_t gfx_pipe_res, uint32_t width, uint32_t height)
+{
+    int ret_status;
+    glBindFramebuffer(GL_FRAMEBUFFER, gfx_pipe_res.fbo);
+
+    glViewport(0, 0, width, height);
+    glUseProgram(gfx_pipe_res.program);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, gfx_pipe_res.textures[0]);
+    glUniform1i(glGetUniformLocation(gfx_pipe_res.program, "tex"), 0);
+    glBindBuffer(GL_ARRAY_BUFFER, gfx_pipe_res.vbo);
+
+    glClearColor(0.0f, 0.0f, 0.0f,0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    ret_status = setup_gl_ver_Attr(&gfx_pipe_res.posAttrib, &gfx_pipe_res.texAttrib, gfx_pipe_res.program);
+    if(ret_status == GFX_GET_ATTRI_SUCCESS) {
+        printf("[INFO]: posAttrib Loc = %d, texAttrib Loc = %d\n", gfx_pipe_res.posAttrib, gfx_pipe_res.texAttrib);
+    }
+    else {
+        return GFX_GET_ATTRI_FAIL;
+    }
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    glFinish();
+
+    glDisableVertexAttribArray(gfx_pipe_res.posAttrib);
+    glDisableVertexAttribArray(gfx_pipe_res.texAttrib);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    return GFX_RENDER_SUCCESS;
 }

--- a/src/gfx_blitter.h
+++ b/src/gfx_blitter.h
@@ -12,16 +12,6 @@ class gfx_blitter
 {
 private:
 public:
-    void find_operation_type(gfx_blit_image_t *src, gfx_blit_image_t *dst);
-    int load_extensions();
-    int create_program();
-    int compile_shader(GLuint shader_type, const char *shader_source);
-    void decide_shaders(const char **vertex_shader, const char **fragment_shader);
-    EGLImageKHR create_egl_image(struct gbm_bo *bo, EGLDisplay display, const char *buffer_type);
-    int create_fbo(GLuint texture_id, uint32_t width, uint32_t height);
-    int create_gl_buffer();
-    int create_texture(EGLImageKHR image);
-    int setup_gl_ver_Attr(GLint *pos_attri, GLint *tex_attri, GLuint program);
     typedef struct egl_resource {
         struct wl_display *wayland_display;
         EGLDisplay egl_display;
@@ -40,6 +30,7 @@ public:
         GFX_LOAD_EXT_FAIL,
         GFX_GET_ATTRI_SUCCESS,
         GFX_DECIDE_SHADER_FAIL,
+        GFX_RENDER_SUCCESS,
     };
 
     typedef struct gfx_pipeline {
@@ -67,6 +58,18 @@ public:
         -1.0f,  1.0f, 0.0f,  0.0f, 1.0f, // Top-left
          1.0f,  1.0f, 0.0f,  1.0f, 1.0f  // Top-right
     };
+
+    void find_operation_type(gfx_blit_image_t *src, gfx_blit_image_t *dst);
+    int load_extensions();
+    int create_program();
+    int compile_shader(GLuint shader_type, const char *shader_source);
+    void decide_shaders(const char **vertex_shader, const char **fragment_shader);
+    EGLImageKHR create_egl_image(struct gbm_bo *bo, EGLDisplay display, const char *buffer_type);
+    int create_fbo(GLuint texture_id, uint32_t width, uint32_t height);
+    int create_gl_buffer();
+    int create_texture(EGLImageKHR image, EGLDisplay display);
+    int setup_gl_ver_Attr(GLint *pos_attri, GLint *tex_attri, GLuint program);
+    int render(gfx_pipeline_t gfx_pipe_res, uint32_t width, uint32_t height);
 
     gfx_blitter();
     ~gfx_blitter();

--- a/tests/simple_test.c
+++ b/tests/simple_test.c
@@ -1,3 +1,4 @@
+// This is the main application file that uses gfx_blit.h to perform a blit.
 #include "gfx_blit.h"
 #include <gbm.h>
 #include <fcntl.h>
@@ -19,6 +20,7 @@ static void* create_image(gfx_blit_image_t *img, uint32_t width, uint32_t height
         default: fprintf(stderr, "Unsupported format\n"); return NULL;
     }
 
+    // Use GBM_BO_USE_LINEAR for mapping to a CPU address
     struct gbm_bo *bo = gbm_bo_create(gbm_dev, width, height, gbm_fmt, GBM_BO_USE_LINEAR | GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT);
     if (!bo) {
         perror("gbm_bo_create failed");
@@ -38,17 +40,45 @@ static void* create_image(gfx_blit_image_t *img, uint32_t width, uint32_t height
     img->height = height;
     img->format = fmt;
     img->bo = bo;
-    img->stride[0] = stride;
+    img->stride[0] = stride; // Store the stride for the first plane
     return ptr;
 }
 
+static void fill_image(gfx_blit_image_t *img, uint32_t width, uint32_t height, void* ptr) {
+    // Fill with a simple color pattern: a green gradient
+    uint32_t *pixels = (uint32_t *)ptr;
+    for (uint32_t y = 0; y < height; ++y) {
+        for (uint32_t x = 0; x < width; ++x) {
+            uint8_t green_val = (y * 255) / height;
+            pixels[y * (img->stride[0] / 4) + x] = 0xFF000000 | (green_val << 8); // ARGB
+        }
+    }
+}
+
+static void write_to_file(const char* filename, gfx_blit_image_t* img, void* ptr) {
+    FILE* fp = fopen(filename, "wb");
+    if (!fp) {
+        perror("Failed to open output file");
+        return;
+    }
+
+    uint32_t *pixels = (uint32_t *)ptr;
+    for (uint32_t y = 0; y < img->height; ++y) {
+        fwrite(&pixels[y * (img->stride[0] / 4)], img->width, 4, fp);
+    }
+    fclose(fp);
+    printf("Successfully wrote output to %s\n", filename);
+}
+
 int main() {
+    // Open a render node
     drm_fd = open("/dev/dri/card1", O_RDWR | O_CLOEXEC);
     if (drm_fd < 0) {
-        perror("Failed to open render node");
+        perror("Failed to open render node /dev/dri/card0. Make sure to use the correct path.");
         return 1;
     }
 
+    // Create a GBM device
     gbm_dev = gbm_create_device(drm_fd);
     if (!gbm_dev) {
         perror("Failed to create GBM device");
@@ -56,27 +86,50 @@ int main() {
         return 1;
     }
 
-    gfx_blit_image_t *src = malloc(sizeof(gfx_blit_image_t));
-    gfx_blit_image_t *dst = malloc(sizeof(gfx_blit_image_t));
+    // Allocate memory for image structs
+    gfx_blit_image_t *src = (gfx_blit_image_t*)malloc(sizeof(gfx_blit_image_t));
+    gfx_blit_image_t *dst = (gfx_blit_image_t*)malloc(sizeof(gfx_blit_image_t));
+    memset(src, 0, sizeof(gfx_blit_image_t));
+    memset(dst, 0, sizeof(gfx_blit_image_t));
 
-    void *src_ptr = create_image(src, 512, 512, GFX_FORMAT_XRGB8888);
+
+    // Create source image and fill with data
+    void *src_ptr = create_image(src, 512, 512, GFX_FORMAT_ARGB8888);
+    if (!src_ptr) {
+        fprintf(stderr, "Failed to allocate source GBM image\n");
+        return 1;
+    }
+    fill_image(src, src->width, src->height, src_ptr);
+
+    // Create destination image
     void *dst_ptr = create_image(dst, 512, 512, GFX_FORMAT_ARGB8888);
-
-    if (!src_ptr || !dst_ptr) {
-        fprintf(stderr, "Failed to allocate GBM images\n");
+    if (!dst_ptr) {
+        fprintf(stderr, "Failed to allocate destination GBM image\n");
+        gbm_bo_unmap(src->bo, NULL);
+        gbm_bo_destroy(src->bo);
         return 1;
     }
 
-
     src->rotation = GFX_ROTATION_0;
-    dst->rotation = GFX_ROTATION_90;
+    dst->rotation = GFX_ROTATION_0;
 
+    // Call the blitting function
     printf("Executing the test\n");
     int status = gfx_blit(src, dst);
     if (status != 0) {
         fprintf(stderr, "gfx_blit failed with status %d\n", status);
     }
 
+    // Unmap the source buffer
+    //gbm_bo_unmap(src->bo, NULL);
+
+    // Write the output to a file
+    write_to_file("output.argb", dst, dst_ptr);
+
+    // Clean up
+    gbm_bo_unmap(dst->bo, NULL);
+    gbm_bo_destroy(src->bo);
+    gbm_bo_destroy(dst->bo);
     free(src);
     free(dst);
 


### PR DESCRIPTION
- Added render() to handle drawing and attribute setup
- Simplified gfx_blit() flow
- Simplified `simple_test.c`:
  - Fills source image with green gradient
  - Writes rendered output to file (`output.argb`)