### PR TITLE
Add logic to select shaders based on formats

### DIFF
--- a/src/gfx_blit.cpp
+++ b/src/gfx_blit.cpp
@@ -35,7 +35,7 @@ extern "C" int gfx_blit(gfx_blit_image_t *src, gfx_blit_image_t *dst)
     }
 
     gfx_blitter_t.find_operation_type(src, dst);
-    gfx_pipe_res.program = gfx_blitter_t.create_program();
+    gfx_pipe_res.program = gfx_blitter_t.create_program(src->format, dst->format);
     if(gfx_pipe_res.program <= 0) {
         cout << "[INFO]: Failed to creete the program" << endl;
     }

--- a/src/gfx_blitter.cpp
+++ b/src/gfx_blitter.cpp
@@ -50,11 +50,17 @@ void gfx_blitter::find_operation_type(gfx_blit_image_t *src, gfx_blit_image_t *d
     }
 }
 
-void gfx_blitter::decide_shaders(const char **vtx_shader,const char **frag_shader)
+void gfx_blitter::decide_shaders(const char **vtx_shader,const char **frag_shader, gfx_format_t src_fmt, gfx_format_t dst_fmt)
 {
-    gfx_shader_manager shader_manager;
-    *vtx_shader = shader_manager.vertex_shader_source;
-    *frag_shader = shader_manager.fragment_shader_source;
+    int n = sizeof(shader_map)/sizeof(shader_table_t);
+    for(int i = 0; i < n; i++){
+        if(src_fmt == shader_map[i].src_fmt && dst_fmt == shader_map[i].dst_fmt) {
+            *vtx_shader = shader_map[i].v_shader;
+            *frag_shader = shader_map[i].f_shader;
+            break;
+        }
+    }
+    printf("[DEBUG]: vertex_shader = %s & fragment_shader = %s\n", *vtx_shader, *frag_shader);
 }
 
 int gfx_blitter::compile_shader(GLuint shader_type,const char *shader_source)
@@ -74,11 +80,11 @@ int gfx_blitter::compile_shader(GLuint shader_type,const char *shader_source)
     return shader;
 }
 
-int gfx_blitter::create_program()
+int gfx_blitter::create_program(gfx_format_t src_fmt, gfx_format_t dst_fmt)
 {
     const char *vertex_shader = "NONE";
     const char *fragment_shader = "NONE";
-    decide_shaders(&vertex_shader, &fragment_shader);
+    decide_shaders(&vertex_shader, &fragment_shader, src_fmt, dst_fmt);
     if(!strcmp(vertex_shader, "NONE") || !strcmp(fragment_shader,"NONE")) {
         printf("[ERROR]: Failed to choose the shaders\n");
         printf("[ERROR]: vertex_shader = %s & fragment_shader = %s\n", vertex_shader, fragment_shader);
@@ -163,7 +169,7 @@ int gfx_blitter::create_texture(EGLImageKHR image, EGLDisplay display)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
-    //eglDestroyImageKHR(display, image);
+    eglDestroyImageKHR(display, image);
     return texture;
 }
 

--- a/src/gfx_blitter.h
+++ b/src/gfx_blitter.h
@@ -8,7 +8,7 @@ extern PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR;
 extern PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR;
 extern PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES;
 extern PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT;
-class gfx_blitter
+class gfx_blitter : public gfx_shader_manager
 {
 private:
 public:
@@ -49,6 +49,41 @@ public:
         GFX_CSC = 0x4,
     };
 
+    typedef struct shader_table {
+        gfx_format_t src_fmt;
+        gfx_format_t dst_fmt;
+        const char *v_shader;
+        const char *f_shader;
+    } shader_table_t;
+
+    shader_table_t shader_map[50] = {
+        {GFX_FORMAT_ARGB8888, GFX_FORMAT_RGBA8888, "vertex_shader", "argb_to_rgba_fs"},
+        {GFX_FORMAT_ARGB8888, GFX_FORMAT_RGB888,   "vertex_shader", "argb_to_rgb_fs"},
+        {GFX_FORMAT_ARGB8888, GFX_FORMAT_XRGB8888, "vertex_shader", "argb_to_xrgb_fs"},
+        {GFX_FORMAT_ARGB8888, GFX_FORMAT_NV12,     "vertex_shader", "argb_to_nv12_fs"},
+        {GFX_FORMAT_ARGB8888, GFX_FORMAT_ARGB8888, vertex_shader,    argb_to_argb_fs},
+        {GFX_FORMAT_RGBA8888, GFX_FORMAT_ARGB8888, "vertex_shader", "rgba_to_argb_fs"},
+        {GFX_FORMAT_RGBA8888, GFX_FORMAT_RGB888,   "vertex_shader", "rgba_to_rgb_fs"},
+        {GFX_FORMAT_RGBA8888, GFX_FORMAT_XRGB8888, "vertex_shader", "rgba_to_xrgb_fs"},
+        {GFX_FORMAT_RGBA8888, GFX_FORMAT_NV12,     "vertex_shader", "rgba_to_nv12_fs"},
+        {GFX_FORMAT_RGBA8888, GFX_FORMAT_RGBA8888, "vertex_shader", "rgba_to_rgba_fs"},
+        {GFX_FORMAT_RGB888,   GFX_FORMAT_ARGB8888, "vertex_shader", "rgb_to_argb_fs"},
+        {GFX_FORMAT_RGB888,   GFX_FORMAT_RGBA8888, "vertex_shader", "rgb_to_rgba_fs"},
+        {GFX_FORMAT_RGB888,   GFX_FORMAT_XRGB8888, "vertex_shader", "rgb_to_xrgb_fs"},
+        {GFX_FORMAT_RGB888,   GFX_FORMAT_NV12,     "vertex_shader", "rgb_to_nv12_fs"},
+        {GFX_FORMAT_RGB888,  GFX_FORMAT_RGB888,    "vertex_shader", "rgb_to_rgb_fs"},
+        {GFX_FORMAT_XRGB8888, GFX_FORMAT_ARGB8888, "vertex_shader", "xrgb_to_argb_fs"},
+        {GFX_FORMAT_XRGB8888, GFX_FORMAT_RGBA8888, "vertex_shader", "xrgb_to_rgba_fs"},
+        {GFX_FORMAT_XRGB8888, GFX_FORMAT_RGB888,   "vertex_shader", "xrgb_to_rgb_fs"},
+        {GFX_FORMAT_XRGB8888, GFX_FORMAT_NV12,     "vertex_shader", "xrgb_to_nv12_fs"},
+        {GFX_FORMAT_XRGB8888, GFX_FORMAT_XRGB8888, "vertex_shader", "xrgb_to_xrgb_fs"},
+        {GFX_FORMAT_NV12,     GFX_FORMAT_ARGB8888, "vertex_shader", "nv12_to_argb_fs"},
+        {GFX_FORMAT_NV12,     GFX_FORMAT_RGBA8888, "vertex_shader", "nv12_to_rgba_fs"},
+        {GFX_FORMAT_NV12,     GFX_FORMAT_RGB888,   "vertex_shader", "nv12_to_rgb_fs"},
+        {GFX_FORMAT_NV12,     GFX_FORMAT_XRGB8888, "vertex_shader", "nv12_to_xrgb_fs"},
+        {GFX_FORMAT_NV12,     GFX_FORMAT_NV12,     "vertex_shader", "nv12_to_nv12_fs"},
+    };
+
     int type_of_operation = GFX_NONE;
 
     float vertices[20] = {
@@ -61,9 +96,9 @@ public:
 
     void find_operation_type(gfx_blit_image_t *src, gfx_blit_image_t *dst);
     int load_extensions();
-    int create_program();
+    int create_program(gfx_format_t src_fmt, gfx_format_t dst_fmt);
     int compile_shader(GLuint shader_type, const char *shader_source);
-    void decide_shaders(const char **vertex_shader, const char **fragment_shader);
+    void decide_shaders(const char **vertex_shader, const char **fragment_shader, gfx_format_t src_fmt, gfx_format_t dst_fmt);
     EGLImageKHR create_egl_image(struct gbm_bo *bo, EGLDisplay display, const char *buffer_type);
     int create_fbo(GLuint texture_id, uint32_t width, uint32_t height);
     int create_gl_buffer();

--- a/src/gfx_shader.h
+++ b/src/gfx_shader.h
@@ -6,7 +6,7 @@ class gfx_shader_manager
 
 private:
 public:
-    const char* vertex_shader_source = R"(
+    const char* vertex_shader = R"(
       attribute vec3 a_position;
       attribute vec2 a_texCoord;
       varying vec2 v_texCord;
@@ -17,7 +17,7 @@ public:
     )";
 
 
-    const char* fragment_shader_source = R"(
+    const char* argb_to_argb_fs = R"(
       precision mediump float;
       varying vec2 v_texCord;
       uniform sampler2D tex;

--- a/tests/simple_test.c
+++ b/tests/simple_test.c
@@ -102,7 +102,7 @@ int main() {
     fill_image(src, src->width, src->height, src_ptr);
 
     // Create destination image
-    void *dst_ptr = create_image(dst, 512, 512, GFX_FORMAT_ARGB8888);
+    void *dst_ptr = create_image(dst, 1024, 1024, GFX_FORMAT_ARGB8888);
     if (!dst_ptr) {
         fprintf(stderr, "Failed to allocate destination GBM image\n");
         gbm_bo_unmap(src->bo, NULL);


### PR DESCRIPTION
- Pick shaders automatically from src/dst formats.
- Added shader map for format combinations.
- Freed EGL images after creating textures.
- Increased dst image size to 1024x1024 in test.